### PR TITLE
Bump node-fetch from 2.3.0 to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3993,9 +3993,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-            "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-int64": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "typetalk"
     ],
     "dependencies": {
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.6.0"
     },
     "devDependencies": {
         "acorn": "^6.0.0",


### PR DESCRIPTION
[node-fetch - npm](https://www.npmjs.com/package/node-fetch)